### PR TITLE
feat: support 100 tokens per folio

### DIFF
--- a/justfile
+++ b/justfile
@@ -143,6 +143,9 @@ test-amman skip_build="":
     # Run tests
     @anchor test --skip-local-validator --skip-deploy --skip-build
 
+    # Kill solana-test-validator after tests
+    @killall solana-test-validator || true
+
 test-bankrun skip_build="":
     # Go to git workspace root
     @cd "$(git rev-parse --show-toplevel)" || exit 1

--- a/programs/folio/src/instructions/auction/bid.rs
+++ b/programs/folio/src/instructions/auction/bid.rs
@@ -276,12 +276,12 @@ pub fn handler(
     let scaled_dust_limit = ctx.accounts.folio_sell_token_metadata.scaled_dust_amount;
     let basket_presence = folio_basket
         .get_token_presence_per_share_in_basket(&auction.sell, &scaled_folio_token_total_supply)?;
-    // QoL: close auction if we have reached the sell limit
 
     let raw_min_sell_balance_with_dust_limit = scaled_dust_limit
         .checked_add(raw_min_sell_balance.into())
         .ok_or(error!(ErrorCode::MathOverflow))?;
 
+    // QoL: close auction if we have reached the sell limit
     if basket_presence <= raw_min_sell_balance_with_dust_limit {
         auction.auction_run_details[index_of_current_running_auction].end = current_time
             .checked_sub(1)

--- a/programs/folio/src/instructions/user/mint_folio/mint_folio_token.rs
+++ b/programs/folio/src/instructions/user/mint_folio/mint_folio_token.rs
@@ -31,8 +31,6 @@ use shared::{
 /// * `folio_basket` - The folio basket account (PDA) (mut, not signer).
 /// * `user_pending_basket` - The user pending basket account (PDA) (mut, not signer).
 /// * `user_folio_token_account` - The user folio token account (PDA) (mut, not signer).
-///
-/// * `remaining_accounts` - The remaining accounts will represent the folio token accounts of the Folio
 #[derive(Accounts)]
 pub struct MintFolioToken<'info> {
     pub system_program: Program<'info, System>,
@@ -80,12 +78,6 @@ pub struct MintFolioToken<'info> {
         associated_token::authority = user,
     )]
     pub user_folio_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
-    /*
-    The remaining accounts need to match the order of amounts as parameter
-
-    Remaining accounts will have as many as possible of the following (always in the same order):
-        - Folio Token Account (in same order as pending token amounts)
-     */
 }
 
 impl MintFolioToken<'_> {
@@ -139,20 +131,10 @@ pub fn handler<'info>(
         folio.bump
     };
 
-    let remaining_accounts = &ctx.remaining_accounts;
-
-    let folio_key = ctx.accounts.folio.key();
     let token_mint_key = ctx.accounts.folio_token_mint.key();
-    let token_program_id = ctx.accounts.token_program.key();
     let current_time = Clock::get()?.unix_timestamp;
 
     let folio_basket = &mut ctx.accounts.folio_basket.load_mut()?;
-
-    // Validate the user passes as many remaining accounts as the folio has mints (validation on those mints is done later)
-    check_condition!(
-        folio_basket.get_total_number_of_mints() == remaining_accounts.len() as u8,
-        InvalidNumberOfRemainingAccounts
-    );
 
     let token_amounts_user = &mut ctx.accounts.user_pending_basket.load_mut()?;
 
@@ -169,12 +151,9 @@ pub fn handler<'info>(
         token_amounts_user.to_assets(
             raw_shares,
             ctx.accounts.folio_token_mint.supply,
-            &folio_key,
-            &token_program_id,
             folio_basket,
             folio,
             PendingBasketType::MintProcess,
-            remaining_accounts,
             current_time,
             fee_details.scaled_fee_numerator,
             fee_details.scaled_fee_denominator,

--- a/programs/folio/src/utils/accounts/folio_basket.rs
+++ b/programs/folio/src/utils/accounts/folio_basket.rs
@@ -40,7 +40,8 @@ impl FolioBasket {
 
             folio_basket.bump = context_bump;
             folio_basket.folio = *folio;
-            folio_basket.token_amounts = [FolioTokenAmount::default(); MAX_FOLIO_TOKEN_AMOUNTS];
+            folio_basket.basket.token_amounts =
+                [FolioTokenAmount::default(); MAX_FOLIO_TOKEN_AMOUNTS];
 
             folio_basket.add_tokens_to_basket(added_folio_token_amounts)?;
         } else {
@@ -72,6 +73,7 @@ impl FolioBasket {
             );
 
             let token_is_present = self
+                .basket
                 .token_amounts
                 .iter_mut()
                 .find(|ta| ta.mint == folio_token_amount.mint);
@@ -86,6 +88,7 @@ impl FolioBasket {
             }
 
             let empty_slot = self
+                .basket
                 .token_amounts
                 .iter_mut()
                 .find(|ta| ta.mint == Pubkey::default());
@@ -114,6 +117,7 @@ impl FolioBasket {
     ) -> Result<()> {
         for folio_token_amount in folio_token_amounts {
             if let Some(slot_to_update) = self
+                .basket
                 .token_amounts
                 .iter_mut()
                 .find(|ta| ta.mint == folio_token_amount.mint)
@@ -137,7 +141,12 @@ impl FolioBasket {
     /// mint: The mint to remove from the basket
     ///
     pub fn remove_token_mint_from_basket(&mut self, mint: Pubkey) -> Result<()> {
-        if let Some(slot_to_update) = self.token_amounts.iter_mut().find(|ta| ta.mint == mint) {
+        if let Some(slot_to_update) = self
+            .basket
+            .token_amounts
+            .iter_mut()
+            .find(|ta| ta.mint == mint)
+        {
             slot_to_update.amount = 0;
             slot_to_update.mint = Pubkey::default();
             emit!(BasketTokenRemoved { token: mint });
@@ -153,7 +162,8 @@ impl FolioBasket {
     ///
     /// # Returns the total number of mints in the basket (non default pubkey).
     pub fn get_total_number_of_mints(&self) -> u8 {
-        self.token_amounts
+        self.basket
+            .token_amounts
             .iter()
             .filter(|ta| ta.mint != Pubkey::default())
             .count() as u8
@@ -168,7 +178,7 @@ impl FolioBasket {
     ///
     /// # Returns the token amount in the basket
     pub fn get_token_amount_in_folio_basket(&self, mint: &Pubkey) -> Result<u64> {
-        let token_amount = self.token_amounts.iter().find(|ta| ta.mint == *mint);
+        let token_amount = self.basket.token_amounts.iter().find(|ta| ta.mint == *mint);
 
         if let Some(token_amount) = token_amount {
             Ok(token_amount.amount)

--- a/programs/folio/src/utils/structs/folio_token_amount.rs
+++ b/programs/folio/src/utils/structs/folio_token_amount.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use bytemuck::{Pod, Zeroable};
+use shared::constants::MAX_FOLIO_TOKEN_AMOUNTS;
 
 /// Store the amount of tokens in the folio basket and the mint of the token.
 #[derive(
@@ -22,3 +23,24 @@ pub struct FolioTokenAmount {
     /// Scaled in D9
     pub amount: u64,
 }
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, InitSpace)]
+#[repr(C)]
+pub struct FolioTokenBasket {
+    /// We do it like this to be able to use the zerocopy traits.
+    pub token_amounts: [FolioTokenAmount; MAX_FOLIO_TOKEN_AMOUNTS],
+}
+
+impl Default for FolioTokenBasket {
+    fn default() -> Self {
+        Self {
+            token_amounts: [FolioTokenAmount::default(); MAX_FOLIO_TOKEN_AMOUNTS],
+        }
+    }
+}
+
+/// From the crate these are only derived for array of some sizes, we wanted a specific one for an array of 100.
+/// The ones close to the limit that comes in library are size 96 and 128.
+/// If we go with 128 we will increase the iteration in some parts of the smart contract.
+unsafe impl Pod for FolioTokenBasket {}
+unsafe impl Zeroable for FolioTokenBasket {}

--- a/programs/folio/src/utils/structs/token_amount.rs
+++ b/programs/folio/src/utils/structs/token_amount.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use bytemuck::{Pod, Zeroable};
+use shared::constants::MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS;
 
 /// A token amount with a mint and an amount for minting and redeeming.
 ///
@@ -27,3 +28,20 @@ pub struct TokenAmount {
     /// Scaled in D9
     pub amount_for_redeeming: u64,
 }
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, InitSpace)]
+#[repr(C)]
+pub struct UserTokenBasket {
+    pub token_amounts: [TokenAmount; MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS],
+}
+
+impl Default for UserTokenBasket {
+    fn default() -> Self {
+        Self {
+            token_amounts: [TokenAmount::default(); MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS],
+        }
+    }
+}
+
+unsafe impl Pod for UserTokenBasket {}
+unsafe impl Zeroable for UserTokenBasket {}

--- a/shared/src/constants/common.rs
+++ b/shared/src/constants/common.rs
@@ -53,11 +53,11 @@ pub const MAX_FEE_RECIPIENTS: usize = 64;
 /// MAX_FEE_RECIPIENTS_PORTION is the maximum portion of the fee that can be set for a fee recipient, 1e18.
 pub const MAX_FEE_RECIPIENTS_PORTION: u128 = 1_000_000_000_000_000_000;
 /// MAX_FOLIO_TOKEN_AMOUNTS is the maximum number of token amounts that can be set for a folio, 16.
-pub const MAX_FOLIO_TOKEN_AMOUNTS: usize = 16;
+pub const MAX_FOLIO_TOKEN_AMOUNTS: usize = 100;
 
 /// MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS is the maximum number of token amounts that can be set for a user pending
-/// basket, 20, higher than our 16 maximum token, since they can have tokens that have been removed / added
-pub const MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS: usize = 20;
+/// basket, 110, higher than our 100 maximum token, since they can have tokens that have been removed / added
+pub const MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS: usize = 110;
 /// MAX_CONCURRENT_AUCTIONS is the maximum number of concurrent auctions that can be set for a folio, 16.
 pub const MAX_CONCURRENT_AUCTIONS: usize = 16;
 /// MAX_REWARD_TOKENS is the maximum number of reward tokens that can be set for a folio, 4.

--- a/tests-ts/bankrun/bankrun-account-helper.ts
+++ b/tests-ts/bankrun/bankrun-account-helper.ts
@@ -691,7 +691,7 @@ export async function createAndSetFolioBasket(
     foliotokenAmounts: foliotokenAmounts,
   };
 
-  const buffer = Buffer.alloc(688);
+  const buffer = Buffer.alloc(4048);
   let offset = 0;
 
   // Encode discriminator
@@ -756,7 +756,7 @@ export async function createAndSetUserPendingBasket(
     tokenAmounts: tokenAmounts,
   };
 
-  const buffer = Buffer.alloc(1040);
+  const buffer = Buffer.alloc(5360);
   let offset = 0;
 
   // Encode discriminator

--- a/tests-ts/bankrun/bankrun-ix-helper.ts
+++ b/tests-ts/bankrun/bankrun-ix-helper.ts
@@ -612,7 +612,6 @@ export async function mintFolioToken<T extends boolean = true>(
   tokens: { mint: PublicKey; amount: BN }[],
   shares: BN,
   executeTxn: T = true as T,
-  remainingAccounts: AccountMeta[] = [],
   minRawShares: BN | null = null
 ) {
   const mintFolioToken = await programFolio.methods
@@ -633,11 +632,6 @@ export async function mintFolioToken<T extends boolean = true>(
         userKeypair.publicKey
       ),
     })
-    .remainingAccounts(
-      remainingAccounts.length > 0
-        ? remainingAccounts
-        : await buildRemainingAccounts(context, tokens, folio, null, false)
-    )
     .instruction();
 
   if (executeTxn) {
@@ -659,8 +653,7 @@ export async function burnFolioToken<T extends boolean = true>(
   folioTokenMint: PublicKey,
   amountToBurn: BN,
   tokens: { mint: PublicKey; amount: BN }[],
-  executeTxn: T = true as T,
-  remainingAccounts: AccountMeta[] = []
+  executeTxn: T = true as T
 ) {
   const burnFolioTokenIx = await programFolio.methods
     .burnFolioToken(amountToBurn)
@@ -681,11 +674,6 @@ export async function burnFolioToken<T extends boolean = true>(
         userKeypair.publicKey
       ),
     })
-    .remainingAccounts(
-      remainingAccounts.length > 0
-        ? remainingAccounts
-        : await buildRemainingAccounts(context, tokens, folio, null, false)
-    )
     .instruction();
 
   if (executeTxn) {

--- a/tests-ts/bankrun/tests/tests-auction.ts
+++ b/tests-ts/bankrun/tests/tests-auction.ts
@@ -1582,9 +1582,10 @@ describe("Bankrun - Auction", () => {
                 getAuctionPDA(folioPDA, auctionToUse.id)
               );
 
-              const folioBasketSellMint = folioBasketAfter.tokenAmounts.find(
-                (token) => token.mint.equals(sellMint.publicKey)
-              );
+              const folioBasketSellMint =
+                folioBasketAfter.basket.tokenAmounts.find((token) =>
+                  token.mint.equals(sellMint.publicKey)
+                );
 
               const currentTimeAfter = new BN(
                 (await context.banksClient.getClock()).unixTimestamp.toString()
@@ -1599,9 +1600,10 @@ describe("Bankrun - Auction", () => {
             }
 
             // Buy mint should be added to the folio basket
-            const folioBasketBuyMint = folioBasketAfter.tokenAmounts.find(
-              (token) => token.mint.equals(buyMint.publicKey)
-            );
+            const folioBasketBuyMint =
+              folioBasketAfter.basket.tokenAmounts.find((token) =>
+                token.mint.equals(buyMint.publicKey)
+              );
 
             assert.notEqual(folioBasketBuyMint, null);
           });

--- a/tests-ts/bankrun/tests/tests-folio-basket.ts
+++ b/tests-ts/bankrun/tests/tests-folio-basket.ts
@@ -521,7 +521,7 @@ describe("Bankrun - Folio basket", () => {
 
               for (let i = 0; i < MAX_FOLIO_TOKEN_AMOUNTS; i++) {
                 assert.equal(
-                  basket.tokenAmounts[i].mint.toString(),
+                  basket.basket.tokenAmounts[i].mint.toString(),
                   expectedTokenAmounts[i].mint.toString()
                 );
 
@@ -538,7 +538,7 @@ describe("Bankrun - Folio basket", () => {
                 const expectedAmount =
                   alreadyIncludedAmount.add(newAmountAdded);
                 assert.equal(
-                  basket.tokenAmounts[i].amount.eq(expectedAmount),
+                  basket.basket.tokenAmounts[i].amount.eq(expectedAmount),
                   true
                 );
               }
@@ -640,7 +640,7 @@ describe("Bankrun - Folio basket", () => {
 
               for (let i = 0; i < MAX_FOLIO_TOKEN_AMOUNTS; i++) {
                 assert.equal(
-                  basket.tokenAmounts[i].mint.toString(),
+                  basket.basket.tokenAmounts[i].mint.toString(),
                   expectedTokenAmounts[i].mint.toString()
                 );
 
@@ -649,7 +649,7 @@ describe("Bankrun - Folio basket", () => {
                 );
                 if (isRemoved) {
                   assert.equal(
-                    basket.tokenAmounts[i].amount.eq(new BN(0)),
+                    basket.basket.tokenAmounts[i].amount.eq(new BN(0)),
                     true
                   );
                 } else {
@@ -660,7 +660,7 @@ describe("Bankrun - Folio basket", () => {
 
                   const expectedAmount = alreadyIncludedAmount;
                   assert.equal(
-                    basket.tokenAmounts[i].amount.eq(expectedAmount),
+                    basket.basket.tokenAmounts[i].amount.eq(expectedAmount),
                     true
                   );
                 }

--- a/tests-ts/tests-folio.ts
+++ b/tests-ts/tests-folio.ts
@@ -545,7 +545,7 @@ describe("Folio Tests", () => {
       await programFolio.account.userPendingBasket.fetch(userPendingBasketPDA);
 
     assert.equal(
-      userPendingBasket.tokenAmounts[0].amountForMinting.toNumber(),
+      userPendingBasket.basket.tokenAmounts[0].amountForMinting.toNumber(),
       100 * 10 ** tokenMints[0].decimals
     );
   });
@@ -618,10 +618,6 @@ describe("Folio Tests", () => {
           userKeypair,
           folioPDA,
           folioTokenMint.publicKey,
-          tokenMints.map((token) => ({
-            mint: token.mint.publicKey,
-            amount: new BN(0),
-          })),
           new BN(1)
         ),
       "MintMismatch",
@@ -712,10 +708,6 @@ describe("Folio Tests", () => {
       userKeypair,
       folioPDA,
       folioTokenMint.publicKey,
-      tokenMints.map((token) => ({
-        mint: token.mint.publicKey,
-        amount: new BN(0),
-      })),
       sharesToMint
     );
 
@@ -767,11 +759,7 @@ describe("Folio Tests", () => {
       userKeypair,
       folioPDA,
       folioTokenMint.publicKey,
-      new BN(2).mul(new BN(DEFAULT_DECIMALS_MUL)),
-      tokenMints.map((token) => ({
-        mint: token.mint.publicKey,
-        amount: new BN(0),
-      }))
+      new BN(2).mul(new BN(DEFAULT_DECIMALS_MUL))
     );
 
     const afterSnapshot = await folioTestHelper.getBalanceSnapshot(

--- a/tests/folio/test_folio_basket.rs
+++ b/tests/folio/test_folio_basket.rs
@@ -5,17 +5,20 @@ mod tests {
     use anchor_lang::prelude::Pubkey;
     use folio::state::FolioBasket;
     use folio::utils::structs::FolioTokenAmount;
+    use folio::utils::FolioTokenBasket;
     use shared::constants::MAX_FOLIO_TOKEN_AMOUNTS;
     use shared::errors::ErrorCode::*;
 
     fn setup_folio_basket() -> FolioBasket {
         let mut basket = FolioBasket {
             folio: Pubkey::new_unique(),
-            token_amounts: [FolioTokenAmount::default(); MAX_FOLIO_TOKEN_AMOUNTS],
+            basket: FolioTokenBasket {
+                token_amounts: [FolioTokenAmount::default(); MAX_FOLIO_TOKEN_AMOUNTS],
+            },
             ..Default::default()
         };
-        basket.token_amounts[0].mint = Pubkey::new_unique();
-        basket.token_amounts[1].mint = Pubkey::new_unique();
+        basket.basket.token_amounts[0].mint = Pubkey::new_unique();
+        basket.basket.token_amounts[1].mint = Pubkey::new_unique();
         basket
     }
 
@@ -30,8 +33,8 @@ mod tests {
                 amount: 100,
             }])
             .unwrap();
-        assert_eq!(basket.token_amounts[2].mint, new_mint);
-        assert_eq!(basket.token_amounts[2].amount, 100);
+        assert_eq!(basket.basket.token_amounts[2].mint, new_mint);
+        assert_eq!(basket.basket.token_amounts[2].amount, 100);
 
         let duplicate_result = basket.add_tokens_to_basket(&vec![FolioTokenAmount {
             mint: new_mint,
@@ -53,14 +56,14 @@ mod tests {
     #[test]
     fn test_remove_token_mint_from_basket() {
         let mut basket = setup_folio_basket();
-        let mint_to_remove = basket.token_amounts[0].mint;
-        basket.token_amounts[0].amount = 100;
+        let mint_to_remove = basket.basket.token_amounts[0].mint;
+        basket.basket.token_amounts[0].amount = 100;
 
         basket
             .remove_token_mint_from_basket(mint_to_remove)
             .unwrap();
-        assert_eq!(basket.token_amounts[0].mint, Pubkey::default());
-        assert_eq!(basket.token_amounts[0].amount, 0);
+        assert_eq!(basket.basket.token_amounts[0].mint, Pubkey::default());
+        assert_eq!(basket.basket.token_amounts[0].amount, 0);
 
         let invalid_mint = Pubkey::new_unique();
         let error = basket.remove_token_mint_from_basket(invalid_mint);
@@ -70,13 +73,13 @@ mod tests {
     #[test]
     fn test_get_total_number_of_mints() {
         let mut basket = setup_folio_basket();
-        basket.token_amounts[0].mint = Pubkey::default();
-        basket.token_amounts[1].mint = Pubkey::default();
+        basket.basket.token_amounts[0].mint = Pubkey::default();
+        basket.basket.token_amounts[1].mint = Pubkey::default();
         assert_eq!(basket.get_total_number_of_mints(), 0);
         let expected_mints = 10;
         for i in 0..expected_mints {
-            basket.token_amounts[i].mint = Pubkey::new_unique();
-            basket.token_amounts[i].amount = 100;
+            basket.basket.token_amounts[i].mint = Pubkey::new_unique();
+            basket.basket.token_amounts[i].amount = 100;
         }
         assert_eq!(basket.get_total_number_of_mints(), expected_mints as u8);
     }
@@ -84,8 +87,8 @@ mod tests {
     #[test]
     fn test_get_token_amount_in_folio_basket() {
         let mut basket = setup_folio_basket();
-        let mint = basket.token_amounts[0].mint;
-        basket.token_amounts[0].amount = 100;
+        let mint = basket.basket.token_amounts[0].mint;
+        basket.basket.token_amounts[0].amount = 100;
 
         let balance = basket.get_token_amount_in_folio_basket(&mint).unwrap();
         assert_eq!(balance, 100);

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -56,8 +56,8 @@ export const MAX_TTL = new BN(604800 * 4);
 export const MAX_RATE = new BN("1000000000000000000000000000");
 
 export const MAX_FEE_RECIPIENTS = 64;
-export const MAX_FOLIO_TOKEN_AMOUNTS = 16;
-export const MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS = 20;
+export const MAX_FOLIO_TOKEN_AMOUNTS = 100;
+export const MAX_USER_PENDING_BASKET_TOKEN_AMOUNTS = 110;
 export const TOTAL_PORTION_FEE_RECIPIENT = new BN("1000000000000000000");
 export const MAX_REWARD_TOKENS = 4;
 export const MAX_CONCURRENT_AUCTIONS = 16;
@@ -70,7 +70,7 @@ export const MIN_REWARD_HALF_LIFE = new BN(86400);
 /*
 Constants for variables used in the tests, don't match with anything on the on-chain program's side.
 */
-export const MAX_TOKENS_IN_BASKET = 16;
+export const MAX_TOKENS_IN_BASKET = 100;
 export const FEE_NUMERATOR: BN = new BN("500000000000000000"); // 50% in D18
 
 export const MAX_SINGLE_AUCTION_RUNS = 10;

--- a/utils/folio-helper.ts
+++ b/utils/folio-helper.ts
@@ -453,7 +453,6 @@ export async function mintFolioToken(
   userKeypair: Keypair,
   folio: PublicKey,
   folioTokenMint: PublicKey,
-  tokens: { mint: PublicKey; amount: BN }[],
   shares: BN,
   minRawShares: BN | null = null
 ) {
@@ -477,16 +476,6 @@ export async function mintFolioToken(
         userKeypair.publicKey
       ),
     })
-    .remainingAccounts(
-      await buildRemainingAccounts(
-        connection,
-        userKeypair,
-        tokens,
-        folio,
-        null,
-        false
-      )
-    )
     .instruction();
 
   await pSendAndConfirmTxn(
@@ -505,8 +494,7 @@ export async function burnFolioToken(
   userKeypair: Keypair,
   folio: PublicKey,
   folioTokenMint: PublicKey,
-  amountToBurn: BN,
-  tokens: { mint: PublicKey; amount: BN }[]
+  amountToBurn: BN
 ) {
   const folioProgram = getFolioProgram(connection, userKeypair);
 
@@ -530,16 +518,6 @@ export async function burnFolioToken(
         userKeypair.publicKey
       ),
     })
-    .remainingAccounts(
-      await buildRemainingAccounts(
-        connection,
-        userKeypair,
-        tokens,
-        folio,
-        null,
-        false
-      )
-    )
     .instruction();
 
   await pSendAndConfirmTxn(

--- a/utils/test-helper.ts
+++ b/utils/test-helper.ts
@@ -180,10 +180,13 @@ export class TestHelper {
     if (expectedDifferences.length > 0) {
       indices.forEach((index) => {
         const afterValue =
-          after.userPendingAmounts.tokenAmounts[index][property].toNumber();
+          after.userPendingAmounts.basket.tokenAmounts[index][
+            property
+          ].toNumber();
         const expectedValue =
-          before.userPendingAmounts.tokenAmounts[index][property].toNumber() +
-          expectedDifferences[index][0];
+          before.userPendingAmounts.basket.tokenAmounts[index][
+            property
+          ].toNumber() + expectedDifferences[index][0];
 
         if (isEstimate) {
           assert.equal(this.floor(afterValue), this.floor(expectedValue));
@@ -192,9 +195,11 @@ export class TestHelper {
         }
 
         const afterFolioValue =
-          after.folioBasketAmounts.tokenAmounts[index].amount.toNumber();
+          after.folioBasketAmounts.basket.tokenAmounts[index].amount.toNumber();
         const beforeFolioValue =
-          before.folioBasketAmounts.tokenAmounts[index].amount.toNumber();
+          before.folioBasketAmounts.basket.tokenAmounts[
+            index
+          ].amount.toNumber();
         if (folioBasketChanged) {
           const expectedDifference = expectedDifferences[index][1];
           let expectedFolioValue =


### PR DESCRIPTION
This PR increases the limit of the folio basket to 100 tokens. It also removes the need for remaining accounts from mint and burn folio token instruction. 