### PR TITLE
fix: TransferFeeConfig mint extension check

### DIFF
--- a/shared/src/utils/token_util.rs
+++ b/shared/src/utils/token_util.rs
@@ -10,17 +10,15 @@ pub struct TokenUtil;
 
 impl TokenUtil {
     /// The forbidden mint extension types.
-    pub const FORBIDDEN_MINT_EXTENSION_TYPES: [ExtensionType; 3] = [
+    pub const FORBIDDEN_MINT_EXTENSION_TYPES: [ExtensionType; 4] = [
         ExtensionType::TransferHook,
         ExtensionType::ConfidentialTransferMint,
         ExtensionType::PermanentDelegate,
+        ExtensionType::TransferFeeConfig,
     ];
 
     /// The forbidden token extension types.
-    pub const FORBIDDEN_TOKEN_EXTENSION_TYPES: [ExtensionType; 2] = [
-        ExtensionType::TransferFeeConfig,
-        ExtensionType::MemoTransfer,
-    ];
+    pub const FORBIDDEN_TOKEN_EXTENSION_TYPES: [ExtensionType; 1] = [ExtensionType::MemoTransfer];
 
     /// Check if the mint has any extensions.
     ///


### PR DESCRIPTION
`TransferFeeConfig` is a mint extension and not a TokenAccount extension.
See: https://github.com/solana-labs/solana-program-library/blob/d72289c79a04411c69a8bf1054f7156b6196f9b3/token/js/src/extensions/extensionType.ts#L106