### PR TITLE
fix: claim_rewards to call accrue rewards for each reward

### DIFF
--- a/tests-ts/bankrun/bankrun-ix-helper.ts
+++ b/tests-ts/bankrun/bankrun-ix-helper.ts
@@ -1540,6 +1540,7 @@ export async function claimRewards<T extends boolean = true>(
 
   if (executeTxn) {
     return createAndProcessTransaction(client, userKeypair, [
+      ...getComputeLimitInstruction(600_000),
       claimRewards,
     ]) as any;
   }


### PR DESCRIPTION
This PR makes, sure that in `claim_rewards` we are calling accrue_rewards for each reward token.