### PR TITLE
feat: add burn slippage minimum amount out

### DIFF
--- a/programs/folio/src/instructions/user/mint_folio/mint_folio_token.rs
+++ b/programs/folio/src/instructions/user/mint_folio/mint_folio_token.rs
@@ -158,6 +158,7 @@ pub fn handler<'info>(
             fee_details.scaled_fee_numerator,
             fee_details.scaled_fee_denominator,
             fee_details.scaled_fee_floor,
+            vec![],
         )?;
     }
 

--- a/programs/folio/src/lib.rs
+++ b/programs/folio/src/lib.rs
@@ -215,8 +215,9 @@ pub mod folio {
     pub fn burn_folio_token<'info>(
         ctx: Context<'_, '_, 'info, 'info, BurnFolioToken<'info>>,
         raw_shares: u64,
+        minimum_out_for_token_amounts: Vec<MinimumOutForTokenAmount>,
     ) -> Result<()> {
-        burn_folio_token::handler(ctx, raw_shares)
+        burn_folio_token::handler(ctx, raw_shares, minimum_out_for_token_amounts)
     }
 
     pub fn redeem_from_pending_basket<'info>(

--- a/programs/folio/src/utils/structs/token_amount.rs
+++ b/programs/folio/src/utils/structs/token_amount.rs
@@ -45,3 +45,10 @@ impl Default for UserTokenBasket {
 
 unsafe impl Pod for UserTokenBasket {}
 unsafe impl Zeroable for UserTokenBasket {}
+
+/// Used for slippage protection when burning folio tokens.
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct MinimumOutForTokenAmount {
+    pub mint: Pubkey,
+    pub minimum_out: u64,
+}

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -303,6 +303,9 @@ pub enum ErrorCode {
 
     #[msg("Rebalance mints and prices and limits length mismatch")]
     RebalanceMintsAndPricesAndLimitsLengthMismatch,
+
+    #[msg("Minimum amount out not met")]
+    MinimumAmountOutNotMet,
 }
 
 /// Check a condition and return an error if it is not met.

--- a/tests-ts/bankrun/bankrun-ix-helper.ts
+++ b/tests-ts/bankrun/bankrun-ix-helper.ts
@@ -645,13 +645,12 @@ export async function burnFolioToken<T extends boolean = true>(
   folio: PublicKey,
   folioTokenMint: PublicKey,
   amountToBurn: BN,
-  tokens: { mint: PublicKey; amount: BN }[],
+  tokens: { mint: PublicKey; minimumOut: BN }[] = [],
   executeTxn: T = true as T
 ) {
   const burnFolioTokenIx = await programFolio.methods
-    .burnFolioToken(amountToBurn)
+    .burnFolioToken(amountToBurn, tokens)
     .accountsPartial({
-      systemProgram: SystemProgram.programId,
       tokenProgram: TOKEN_PROGRAM_ID,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       user: userKeypair.publicKey,

--- a/tests/folio/test_user_pending_basket.rs
+++ b/tests/folio/test_user_pending_basket.rs
@@ -575,6 +575,7 @@ mod tests {
             &decimal_total_supply,
             &decimal_folio_balance,
             &shares,
+            None,
         );
 
         assert!(result.is_ok());
@@ -607,12 +608,46 @@ mod tests {
             &decimal_total_supply,
             &decimal_folio_balance,
             &shares,
+            None,
         );
 
         assert!(result.is_ok());
 
         assert_eq!(user_amount.amount_for_redeeming, 333_333);
         assert_eq!(related_mint.amount, 99666667);
+    }
+
+    #[test]
+    fn test_to_assets_for_redeeming_minimum_amount_out() {
+        let mut user_amount = TokenAmount {
+            mint: Pubkey::new_unique(),
+            amount_for_minting: 0,
+            amount_for_redeeming: 0,
+        };
+
+        let mut related_mint = FolioTokenAmount {
+            mint: user_amount.mint,
+            amount: 100_000_000,
+        };
+
+        let decimal_total_supply = Decimal::from_token_amount(3_000_000u128).unwrap();
+        let decimal_folio_balance = Decimal::from_token_amount(1_000_000u128).unwrap();
+        let shares = Decimal::from_token_amount(1_000_000u64).unwrap(); // D9
+
+        let result = UserPendingBasket::to_assets_for_redeeming(
+            &mut user_amount,
+            &mut related_mint,
+            &decimal_total_supply,
+            &decimal_folio_balance,
+            &shares,
+            Some(100_000_000),
+        );
+
+        assert!(result.is_err()); // Should fail due to division by zero
+        assert_eq!(
+            result.unwrap_err(),
+            ErrorCode::MinimumAmountOutNotMet.into()
+        );
     }
 
     #[test]
@@ -638,6 +673,7 @@ mod tests {
             &decimal_total_supply,
             &decimal_folio_balance,
             &shares,
+            None,
         );
 
         assert!(result.is_err()); // Should fail due to division by zero
@@ -666,6 +702,7 @@ mod tests {
             &decimal_total_supply,
             &decimal_folio_balance,
             &shares,
+            None,
         );
 
         assert!(result.is_ok());

--- a/utils/folio-helper.ts
+++ b/utils/folio-helper.ts
@@ -481,14 +481,14 @@ export async function burnFolioToken(
   userKeypair: Keypair,
   folio: PublicKey,
   folioTokenMint: PublicKey,
-  amountToBurn: BN
+  amountToBurn: BN,
+  minimumOutForTokenAmounts: { mint: PublicKey; minimumOut: BN }[] = []
 ) {
   const folioProgram = getFolioProgram(connection, userKeypair);
 
   const burnFolioTokenIx = await folioProgram.methods
-    .burnFolioToken(amountToBurn)
+    .burnFolioToken(amountToBurn, minimumOutForTokenAmounts)
     .accountsPartial({
-      systemProgram: SystemProgram.programId,
       tokenProgram: TOKEN_PROGRAM_ID,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       user: userKeypair.publicKey,


### PR DESCRIPTION
This PR adds slippage for burn_folio_token, we now accept an array of `minimum_amount_out`, This could contain tokens users are interested in for minimum_amount_out