### PR TITLE
feat: add check for governance mint in reward accrual logic

### DIFF
--- a/programs/rewards/src/instructions/accrue_rewards.rs
+++ b/programs/rewards/src/instructions/accrue_rewards.rs
@@ -133,7 +133,7 @@ pub fn accrue_rewards<'info>(
     // Get the total balance of staked governance tokens in the Realm
     let (raw_governance_staked_token_account_balance, governance_token_decimals) =
         GovernanceUtil::get_realm_staked_balance_and_mint_decimals(
-            &realm_key,
+            realm,
             governance_token_mint,
             governance_staked_token_account,
         )?;
@@ -236,7 +236,7 @@ pub fn accrue_rewards<'info>(
         // Init if needed and accrue rewards on user reward info
         let raw_caller_governance_account_balance = GovernanceUtil::get_governance_account_balance(
             caller_governance_token_account,
-            &realm_key,
+            realm,
             &governance_token_mint_key,
             &caller_key,
         )?;
@@ -281,7 +281,7 @@ pub fn accrue_rewards<'info>(
             let raw_user_governance_account_balance =
                 GovernanceUtil::get_governance_account_balance(
                     user_governance_token_account,
-                    &realm_key,
+                    realm,
                     &governance_token_mint_key,
                     &user_key,
                 )?;

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -229,6 +229,9 @@ pub enum ErrorCode {
     #[msg("Invalid Governance Account")]
     InvalidGovernanceAccount,
 
+    #[msg("Invalid Community Mint")]
+    InvalidCommunityMint,
+
     #[msg("Invalid Fee Recipient Token Account")]
     InvalidFeeRecipientTokenAccount,
 


### PR DESCRIPTION
Tried for some 2 hours to produce the issue with the council mint, but I was not able to as setting up all accounts and everything is hard, I was getting `InvalidAccountData` error. But I don't see any issues with adding this check. 