### PR TITLE
fix: decimals in folio crank fee distribution instruction

### DIFF
--- a/programs/folio/src/instructions/crank/crank_fee_distribution.rs
+++ b/programs/folio/src/instructions/crank/crank_fee_distribution.rs
@@ -339,11 +339,14 @@ pub fn handler<'info>(
             .fee_distribution
             .close(ctx.accounts.cranker.to_account_info())?;
     }
+    let scaled_amount_to_remove_from_folio_pending_fees =
+        Decimal::from_token_amount(amount_to_remove_from_folio_pending_fees)?
+            .to_scaled(Rounding::Floor)?;
 
     let folio = &mut ctx.accounts.folio.load_mut()?;
     folio.fee_recipients_pending_fee_shares_to_be_minted = folio
         .fee_recipients_pending_fee_shares_to_be_minted
-        .checked_sub(amount_to_remove_from_folio_pending_fees)
+        .checked_sub(scaled_amount_to_remove_from_folio_pending_fees)
         .ok_or(ErrorCode::MathOverflow)?;
 
     Ok(())

--- a/tests-ts/bankrun/tests/tests-fees.ts
+++ b/tests-ts/bankrun/tests/tests-fees.ts
@@ -927,6 +927,8 @@ describe("Bankrun - Fees", () => {
 
           const crankerToUse = customCranker || cranker;
 
+          let folioBefore: any;
+
           before(async () => {
             await initBaseCase(
               customFolioTokenMint,
@@ -994,6 +996,8 @@ describe("Bankrun - Fees", () => {
             await travelFutureSlot(context);
 
             const tokenMintToUse = customFolioTokenMint || folioTokenMint;
+
+            folioBefore = await programFolio.account.folio.fetch(folioPDA);
 
             try {
               txnResult = await crankFeeDistribution<true>(
@@ -1081,6 +1085,25 @@ describe("Bankrun - Fees", () => {
                   true
                 );
               }
+
+              const totalFeeDistributed = expectedFeeDistributed.reduce(
+                (acc, curr) => acc.add(curr),
+                new BN(0)
+              );
+              const folioAfter = await programFolio.account.folio.fetch(
+                folioPDA
+              );
+              console.log(
+                folioBefore.feeRecipientsPendingFeeSharesToBeMinted.toString(),
+                totalFeeDistributed.toString(),
+                folioAfter.feeRecipientsPendingFeeSharesToBeMinted.toString()
+              );
+              assert.equal(
+                folioBefore.feeRecipientsPendingFeeSharesToBeMinted
+                  .sub(totalFeeDistributed.mul(D9))
+                  .eq(folioAfter.feeRecipientsPendingFeeSharesToBeMinted),
+                true
+              );
             });
           }
         });


### PR DESCRIPTION
This PR fixes the issues with incorrect subtraction for the folio's feeRecipientsPendingFeeSharesToBeMinted reduction in crank fee distribution