### PR TITLE
chore: allow start of rebalance with 0 mint tokens

### DIFF
--- a/programs/folio/src/utils/accounts/rebalance.rs
+++ b/programs/folio/src/utils/accounts/rebalance.rs
@@ -100,7 +100,7 @@ impl Rebalance {
         let is_price_deferred = if self.details.tokens[0].mint != Pubkey::default() {
             self.details.tokens[0].prices.low == 0
         } else {
-            prices_and_limits[0].prices.low == 0
+            !prices_and_limits.is_empty() && prices_and_limits[0].prices.low == 0
         };
 
         let mut mint_to_process_index = 0;

--- a/tests-ts/bankrun/tests/tests-rebalance.ts
+++ b/tests-ts/bankrun/tests/tests-rebalance.ts
@@ -751,6 +751,24 @@ describe("Bankrun - Rebalance", () => {
         mints: [BUY_MINTS_2022[0].publicKey, DEFAULT_SELL_MINT.publicKey],
       };
     }),
+
+    {
+      desc: "Should add rebalance details with no mints",
+      expectedError: null,
+      existingRebalanceParams: {
+        nonce: new BN(10),
+        currentAuctionId: new BN(1),
+        allRebalanceDetailsAdded: true,
+        auctionLauncherWindow: 100,
+        ttl: 100,
+        startedAt: new BN(100),
+        restrictedUntil: new BN(100),
+        availableUntil: new BN(100),
+      },
+      allRebalanceDetailsAdded: false,
+      pricesAndLimits: [],
+      mints: [],
+    },
   ];
 
   describe("Specific Cases - Start Rebalance", () => {
@@ -843,26 +861,28 @@ describe("Bankrun - Rebalance", () => {
                 allRebalanceDetailsAdded ? 1 : 0
               );
 
-              assert.equal(
-                rebalanceAfter.details.tokens[0].mint.equals(mints[0]),
-                true
-              );
-              assert.equal(
-                rebalanceAfter.details.tokens[1].mint.equals(mints[1]),
-                true
-              );
-              assert.equal(
-                rebalanceAfter.details.tokens[0].prices.low.eq(
-                  pricesAndLimits[0].prices.low
-                ),
-                true
-              );
-              assert.equal(
-                rebalanceAfter.details.tokens[0].prices.high.eq(
-                  pricesAndLimits[0].prices.high
-                ),
-                true
-              );
+              if (mints.length > 0) {
+                assert.equal(
+                  rebalanceAfter.details.tokens[0].mint.equals(mints[0]),
+                  true
+                );
+                assert.equal(
+                  rebalanceAfter.details.tokens[1].mint.equals(mints[1]),
+                  true
+                );
+                assert.equal(
+                  rebalanceAfter.details.tokens[0].prices.low.eq(
+                    pricesAndLimits[0].prices.low
+                  ),
+                  true
+                );
+                assert.equal(
+                  rebalanceAfter.details.tokens[0].prices.high.eq(
+                    pricesAndLimits[0].prices.high
+                  ),
+                  true
+                );
+              }
             });
           }
         });


### PR DESCRIPTION
Improvement: This allows for start of rebalance with 0 mints passed in that instruction.
The mints will be passed in the next instruction.