### PR TITLE
feat: allow creation of fee_recipient and addition of fee recipient in same instruction

### DIFF
--- a/programs/folio/src/instructions/owner/update_folio.rs
+++ b/programs/folio/src/instructions/owner/update_folio.rs
@@ -280,7 +280,11 @@ pub fn handler<'info>(
         }
 
         {
-            let mut fee_recipients = ctx.accounts.fee_recipients.load_mut()?;
+            let fee_recipients_res = &mut ctx.accounts.fee_recipients.load_mut();
+            let fee_recipients = match fee_recipients_res {
+                Ok(fee_recipients) => fee_recipients,
+                Err(_) => &mut ctx.accounts.fee_recipients.load_init()?,
+            };
 
             fee_recipients
                 .update_fee_recipients(fee_recipients_to_add, fee_recipients_to_remove)?;

--- a/shared/src/constants/common.rs
+++ b/shared/src/constants/common.rs
@@ -82,7 +82,7 @@ pub const MAX_TOKEN_PRICE_RANGE: u128 = 100;
 /// MAX_TOKEN_PRICE is the maximum price for a token, 1e36.
 pub const MAX_TOKEN_PRICE: u128 = D18_U128 * D18_U128;
 
-pub const RESTRICTED_AUCTION_BUFFER: u64 = 120;
+pub const RESTRICTED_AUCTION_BUFFER: u64 = 0;
 
 /// MAX_FEE_RECIPIENTS is the maximum number of fee recipients, 64.
 pub const MAX_FEE_RECIPIENTS: usize = 64;


### PR DESCRIPTION
Without this change, updateFolio had to be called twice for a new folio for addition of fee_recipients.
This PR tries to improve the flow.